### PR TITLE
Fix for AnatomicalCoordinatesTable

### DIFF
--- a/spec/ndx-anatomical-localization.extensions.yaml
+++ b/spec/ndx-anatomical-localization.extensions.yaml
@@ -27,12 +27,15 @@ groups:
         dtype: text
         required: true
       - name: orientation
-        doc: "A 3-letter string. One of APLRSI for each of x, y, and z. For example, the most common orientation is 'RAS', which means x is right, y is anterior, and z is superior (a.k.a dorsal). For dorsal/ventral use 'S/I' (superior/inferior)."
+        doc: "A 3-letter string. One of APLRSI for each of x, y, and z. For example, the most common
+          orientation is 'RAS', which means x is right, y is anterior, and z is superior (a.k.a. dorsal).
+          For dorsal/ventral use 'S/I' (superior/inferior). In the AnatomicalCoordinatesTable, an orientation of
+          'RAS' corresponds to coordinates in the order of (ML (x), AP (y), DV (z))."
         dtype: text
         required: true
   - neurodata_type_def: AnatomicalCoordinatesTable
     neurodata_type_inc: DynamicTable
-    doc: "A table for storing coordinates"
+    doc: "A table for storing anatomical coordinates for rows of another table determined using a single method"
     links:
       - target_type: Space
         quantity: 1

--- a/src/pynwb/ndx_anatomical_localization/__init__.py
+++ b/src/pynwb/ndx_anatomical_localization/__init__.py
@@ -8,14 +8,12 @@ except ImportError:
     from importlib_resources import files
 
 # # Get path to the namespace.yaml file with the expected location when installed not in editable mode
-# __location_of_this_file = files(__name__)
-# __spec_path = __location_of_this_file / "spec" / "ndx-anatomical-localization.namespace.yaml"
+__location_of_this_file = files(__name__)
+__spec_path = __location_of_this_file / "spec" / "ndx-anatomical-localization.namespace.yaml"
 
 # # If that path does not exist, we are likely running in editable mode. Use the local path instead
-# if not os.path.exists(__spec_path):
-#     __spec_path = __location_of_this_file.parent.parent.parent / "spec" / "ndx-anatomical-localization.namespace.yaml"
-
-__spec_path = "/Users/bendichter/dev/ndx-anatomical-localization/spec/ndx-anatomical-localization.namespace.yaml"
+if not os.path.exists(__spec_path):
+    __spec_path = __location_of_this_file.parent.parent.parent / "spec" / "ndx-anatomical-localization.namespace.yaml"
 
 # Load the namespace
 load_namespaces(str(__spec_path))

--- a/src/pynwb/tests/test_anatomical_coordinates.py
+++ b/src/pynwb/tests/test_anatomical_coordinates.py
@@ -2,6 +2,8 @@
 from pynwb import NWBHDF5IO
 from pynwb.testing.mock.file import mock_NWBFile
 from pynwb.testing.mock.ecephys import mock_ElectrodeTable
+import numpy as np
+import numpy.testing as npt
 
 from ndx_anatomical_localization import AnatomicalCoordinatesTable, Space, Localization
 
@@ -34,5 +36,17 @@ def test_create_anatomical_coordinates_table():
 
     with NWBHDF5IO("test.nwb", "r", load_namespaces=True) as io:
         read_nwbfile = io.read()
+        read_electrodes_table = read_nwbfile.electrodes
+        read_localization = read_nwbfile.lab_meta_data["localization"]
 
-        assert read_nwbfile.lab_meta_data["localization"]["MyAnatomicalLocalization"].space.space_name == "CCFv3"
+        read_coordinates_table = read_localization.anatomical_coordinates_tables["MyAnatomicalLocalization"]
+
+        assert read_coordinates_table.method == "method"
+        assert read_coordinates_table.description == "Anatomical coordinates table"
+        assert read_coordinates_table.target_object.table is read_electrodes_table
+        assert read_coordinates_table.space.fields == Space.get_predefined_space("CCFv3").fields
+        npt.assert_array_equal(read_coordinates_table["x"].data[:], np.array([1.0, 1.0, 1.0, 1.0, 1.0]))
+        npt.assert_array_equal(read_coordinates_table["y"].data[:], np.array([2.0, 2.0, 2.0, 2.0, 2.0]))
+        npt.assert_array_equal(read_coordinates_table["z"].data[:], np.array([3.0, 3.0, 3.0, 3.0, 3.0]))
+        npt.assert_array_equal(read_coordinates_table["brain_region"].data[:], np.array(["CA1", "CA1", "CA1", "CA1", "CA1"]))
+        npt.assert_array_equal(read_coordinates_table["target_object"].data[:], np.array([0, 1, 2, 3, 4]))


### PR DESCRIPTION
1. Fix for `AnatomicalCoordinatesTable.__init__` - I opted to go the optional argument route because 1) I think it is awkward to require `target` when a user might want to provide the `columns` manually, e.g., to create the VectorData columns one at a time and construct the table from the columns rather than calling `add_row` repeatedly and 2) I generally prefer to avoid object mapper magic because it is confusing and not obvious to non-core maintainers. Happy to hear reasons to prefer the object mapper approach though. Fix #1.
2. I clarified some spec docs a bit.